### PR TITLE
Added posibility to scroll in the menu

### DIFF
--- a/hamburgler.css
+++ b/hamburgler.css
@@ -74,6 +74,7 @@
     position: fixed;
     width: 100%;
     height: 100%;
+    overflow: auto;
     background: rgba(0, 0, 0, 0.9);
 }
 .mobilenav li {


### PR DESCRIPTION
If the navigation menu is very long, then it will not fit into the window. By adding overflow auto to the nav, it will be scrollable, instead of scrolling the content behind the navigation.
